### PR TITLE
Adapted code regarding removal of `MeetingConfig.useGroupsAsCategories`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Changelog
 - Completed `test_ws_meetingAcceptingItems` to check that it works when using
   `inTheNameOf` (was actually not working before `Products.PloneMeeting==4.2rc30`).
   [gbastien]
+- Adapted code regarding removal of `MeetingConfig.useGroupsAsCategories`.
+  [gbastien]
 
 3.6 (2022-03-10)
 ----------------

--- a/src/imio/pm/ws/tests/WS4PMTestCase.py
+++ b/src/imio/pm/ws/tests/WS4PMTestCase.py
@@ -35,12 +35,11 @@ class WS4PMTestCase(PloneMeetingTestCase):
         self.meetingConfig.setUsedItemAttributes(itemAttrs + ('detailedDescription', ))
         itemAttrs = self.meetingConfig2.getUsedItemAttributes()
         self.meetingConfig2.setUsedItemAttributes(itemAttrs + ('detailedDescription', ))
-        # use the 'plonegov-assembly' MeetingConfig that use real categories,
-        # not useGroupsAsCategories, even if it could be changed during a test
+        # use the 'plonegov-assembly' MeetingConfig that use category
         self.meetingConfig = self.meetingConfig2
         self.usedMeetingConfigId = 'plonegov-assembly'
 
-    def _prepareCreationData(self):
+    def _prepareCreationData(self, with_category=True):
         """
           Helper method for creating an item using the SOAP method createItem
         """
@@ -52,7 +51,8 @@ class WS4PMTestCase(PloneMeetingTestCase):
         req._proposingGroupId = 'developers'
         CreationData = GTD('http://ws4pm.imio.be', 'CreationData')('').pyclass()
         CreationData._title = 'My new item title'
-        CreationData._category = 'development'
+        if with_category:
+            CreationData._category = 'development'
         CreationData._description = '<p>Description</p>'
         CreationData._detailedDescription = '<p>Detailed description</p>'
         CreationData._decision = '<p>Décision</p>'

--- a/src/imio/pm/ws/tests/test_createitem.py
+++ b/src/imio/pm/ws/tests/test_createitem.py
@@ -106,7 +106,7 @@ SOAPAction: /
         """
         # by default no item exists
         self.changeUser('pmCreator1')
-        req = self._prepareCreationData()
+        req = self._prepareCreationData(with_category=False)
         responseHolder = createItemResponse()
         # the title is mandatory
         req._creationData._title = None
@@ -129,21 +129,20 @@ SOAPAction: /
         # set back correct proposingGroup
         req._proposingGroupId = 'developers'
         # if category is mandatory and empty, it raises ZSI.Fault
-        self.meetingConfig.setUseGroupsAsCategories(False)
+        self._enableField('category')
         req._creationData._category = None
         with self.assertRaises(ZSI.Fault) as cm:
             SOAPView(self.portal, req).createItemRequest(req, responseHolder)
         self.assertEqual(cm.exception.string, "In this config, category is mandatory!")
-        # wrong category and useGroupsAsCategories, ZSI.Fault
-        self.meetingConfig.setUseGroupsAsCategories(True)
+        # wrong category and category not used, ZSI.Fault
+        self._enableField('category', enable=False)
         req._creationData._category = 'wrong-category-id'
         with self.assertRaises(ZSI.Fault) as cm:
             SOAPView(self.portal, req).createItemRequest(req, responseHolder)
         self.assertEqual(cm.exception.string,
-                         "This config does not use categories, the given 'wrong-category-id' "
-                         "category can not be used!")
-        # wrong category and actually accepting categories, aka useGroupsAsCategories to False
-        self.meetingConfig.setUseGroupsAsCategories(False)
+                         'The optional field "category" is not activated in this configuration!')
+        # wrong category and using category
+        self._enableField('category')
         with self.assertRaises(ZSI.Fault) as cm:
             SOAPView(self.portal, req).createItemRequest(req, responseHolder)
         self.assertEqual(cm.exception.string,
@@ -190,7 +189,7 @@ SOAPAction: /
         req = self._prepareCreationData()
         responseHolder = createItemResponse()
         # we can not use an optional field that is not activated in the current MeetingConfig
-        cfg.setUsedItemAttributes(('description', 'detailedDescription',))
+        cfg.setUsedItemAttributes(('category', 'description', 'detailedDescription',))
         self.assertFalse('toDiscuss' in cfg.getUsedItemAttributes())
         # set toDiscuss to True
         req._creationData._toDiscuss = True
@@ -493,7 +492,7 @@ SOAPAction: /
           - the calling user must be 'Manager' or 'MeetingManager'
           - the created item is finally like if created by the inTheNameOf user
         """
-        self.meetingConfig.setUseGroupsAsCategories(False)
+        self._enableField('category')
         # check first a working example the degrades it...
         # and every related informations (creator, ownership, ...) are corretly linked to inTheNameOf user
         self.changeUser('pmManager')
@@ -653,7 +652,7 @@ SOAPAction: /
           Test when passing groupsInCharge while creating the item.
         """
         cfg = self.meetingConfig
-        cfg.setUsedItemAttributes(['description', 'detailedDescription'])
+        cfg.setUsedItemAttributes(['category', 'description', 'detailedDescription'])
         # by default no item exists
         self.changeUser('pmCreator1')
         req = self._prepareCreationData()
@@ -686,7 +685,7 @@ SOAPAction: /
           Test when passing associatedGroups while creating the item.
         """
         cfg = self.meetingConfig
-        cfg.setUsedItemAttributes(['description', 'detailedDescription'])
+        cfg.setUsedItemAttributes(['category', 'description', 'detailedDescription'])
         # by default no item exists
         self.changeUser('pmCreator1')
         req = self._prepareCreationData()
@@ -718,7 +717,7 @@ SOAPAction: /
           Test when passing associatedGroups while creating the item.
         """
         cfg = self.meetingConfig
-        cfg.setUsedItemAttributes(['description', 'detailedDescription'])
+        cfg.setUsedItemAttributes(['category', 'description', 'detailedDescription'])
 
         # by default no item exists
         self.changeUser('pmCreator1')

--- a/src/imio/pm/ws/tests/test_getconfiginfos.py
+++ b/src/imio/pm/ws/tests/test_getconfiginfos.py
@@ -217,7 +217,7 @@ class testSOAPGetConfigInfos(WS4PMTestCase):
           Helper method for generating result displayed about categories of a MeetingConfig
         """
         # if not using categories, return empty categories list
-        if not config.meta_type == 'MeetingConfig' or config.getUseGroupsAsCategories():
+        if not config.meta_type == 'MeetingConfig' or 'category' not in config.getUsedItemAttributes():
             return ''
 
         result = ""

--- a/src/imio/pm/ws/tests/test_searchitems.py
+++ b/src/imio/pm/ws/tests/test_searchitems.py
@@ -110,8 +110,7 @@ class testSOAPSearchItems(WS4PMTestCase):
         self.assertEqual(expected, resp)
         # if the item is in a meeting, the result is a bit different because
         # we have valid informations about the meeting_date
-        # use the 'plonegov-assembly' MeetingConfig that use real categories,
-        # not useGroupsAsCategories
+        # use the 'plonegov-assembly' MeetingConfig that use category
         self.changeUser('pmManager')
         meeting = self._createMeetingWithItems()
         itemInMeeting = meeting.get_items(ordered=True)[0]
@@ -201,7 +200,7 @@ class testSOAPSearchItems(WS4PMTestCase):
         # create an item for 'plonemeeting-assembly' with same data as one created for 'plonegov-assembly' here above
         req = self._prepareCreationData()
         req._meetingConfigId = 'plonemeeting-assembly'
-        # in 'plonemeeting-assembly', the category is not used, useGroupsAsCategories is True
+        # in 'plonemeeting-assembly', the category is not used
         req._creationData._category = ''
         newItem, response = self._createItem(req)
         pmItem = self.portal.portal_catalog(UID=response._UID)[0].getObject()


### PR DESCRIPTION
See #PM-1008